### PR TITLE
Update compact_str to v0.4

### DIFF
--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
  "criterion",
  "flexstr 0.8.0",
  "flexstr 0.8.1",
- "flexstr 0.8.1 (git+https://github.com/nu11ptr/flexstr)",
+ "flexstr 0.9.2",
  "kstring",
  "smartstring",
  "smol_str",
@@ -206,16 +206,16 @@ checksum = "a44498e554d7c8e2f2949d1652c3bfb5dbd4a2d801c54560b76a4697c7edace2"
 [[package]]
 name = "flexstr"
 version = "0.8.1"
+source = "git+https://github.com/nu11ptr/flexstr#ade032ae931c8ccf16eb6c3f1abb3beb8dec11cf"
+
+[[package]]
+name = "flexstr"
+version = "0.9.2"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
  "static_assertions",
 ]
-
-[[package]]
-name = "flexstr"
-version = "0.8.1"
-source = "git+https://github.com/nu11ptr/flexstr#ade032ae931c8ccf16eb6c3f1abb3beb8dec11cf"
 
 [[package]]
 name = "half"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -25,7 +25,7 @@ harness = false
 [dependencies]
 
 [dev-dependencies]
-compact_str = "0.3"
+compact_str = "0.4"
 criterion = { version = "0.3", features = ["real_blackbox"] }
 flexstr = { path = "../flexstr", features = ["fp_convert", "int_convert"] }
 flexstr_080 = { package = "flexstr", version = "0.8.0" }

--- a/benchmarks/benches/clone.rs
+++ b/benchmarks/benches/clone.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use flexstr::{AFlexStr, AFlexStr_, FlexStr, FlexStr_, Repeat};
 use kstring::KString;
@@ -75,8 +75,8 @@ clone!(
     |len| -> FlexStr_ { (&*"x".repeat(len)).into() },
     "AFlexStr_",
     |len| -> AFlexStr_ { (&*"x".repeat(len)).into() },
-    "CompactStr",
-    |len| -> CompactStr { "x".repeat(len).into() },
+    "CompactString",
+    |len| -> CompactString { "x".repeat(len).into() },
     "KString",
     |len| -> KString { "x".repeat(len).into() },
     "SmartString",

--- a/benchmarks/benches/create.rs
+++ b/benchmarks/benches/create.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use flexstr::{AFlexStr, AFlexStr_, FlexStr, FlexStr_, Repeat, ToAFlexStr, ToFlexStr};
 use kstring::KString;
@@ -67,8 +67,8 @@ create!(
     |s: &str| FlexStr_::from(s),
     "AFlexStr_",
     |s: &str| AFlexStr_::from(s),
-    "CompactStr",
-    |s: &str| CompactStr::new(s),
+    "CompactString",
+    |s: &str| CompactString::new(s),
     "KString",
     |s: &str| KString::from_ref(s),
     "SmartString",


### PR DESCRIPTION
**Context**
In the most recent version of [`compact_str`](https://github.com/ParkMyCar/compact_str), we renamed `CompactStr` to `CompactString`. You can continue to use `CompactStr` but there is a deprecation warning on it.

**Changes**
This PR updates `compact_str` to `v0.4`, renaming uses of `CompactStr` to `CompactString` to prevent the warning