### PR TITLE
Fix typo in features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Optional features:
 ```toml
 [dependencies.flexstr]
 version = "0.9"
-features = ["fast_format, fp_convert", "int_convert", "serde"]
+features = ["fast_format", "fp_convert", "int_convert", "serde"]
 ```
 
 ## How Does It Work?


### PR DESCRIPTION
It took me a while to realize what the issue was, as the error output was correct, but also easy to miss the actual typo/reason:

```
the package `x` depends on `flexstr`, with features: `fast_format, fp_convert` but `flexstr` does not have these features.
```