### PR TITLE
Fix compilation errors on platforms that don't support alloc::sync::Arc

### DIFF
--- a/flexstr/src/lib.rs
+++ b/flexstr/src/lib.rs
@@ -90,13 +90,14 @@ pub mod traits;
 
 use alloc::rc::Rc;
 use alloc::string::String;
+#[cfg(target_has_atomic = "ptr")]
 use alloc::sync::Arc;
 use core::fmt::{Arguments, Write};
 use core::mem;
 use core::mem::ManuallyDrop;
 use core::ops::Deref;
 
-use static_assertions::{assert_eq_align, assert_eq_size, assert_impl_all, assert_not_impl_any};
+use static_assertions::{assert_eq_align, assert_eq_size, assert_not_impl_any};
 
 use crate::storage::heap::HeapStr;
 use crate::storage::inline::InlineFlexStr;
@@ -120,8 +121,13 @@ mod test_readme {
 }
 
 assert_eq_size!(LocalStr, String);
-assert_eq_size!(SharedStr, String);
 assert_not_impl_any!(LocalStr: Send, Sync);
+
+#[cfg(target_has_atomic = "ptr")]
+use static_assertions::assert_impl_all;
+#[cfg(target_has_atomic = "ptr")]
+assert_eq_size!(SharedStr, String);
+#[cfg(target_has_atomic = "ptr")]
 assert_impl_all!(SharedStr: Send, Sync);
 
 assert_eq_size!(HeapStr<PTR_SIZED_PAD, Rc<str>>, InlineFlexStr<STRING_SIZED_INLINE>);
@@ -172,6 +178,7 @@ pub type LocalStr = FlexStrBase<Rc<str>>;
 ///
 /// # Note
 /// Since this is just a type alias for a generic type, full documentation can be found here: [FlexStr]
+#[cfg(target_has_atomic = "ptr")]
 pub type SharedStr = FlexStrBase<Arc<str>>;
 
 // *** Clone ***

--- a/flexstr/src/traits.rs
+++ b/flexstr/src/traits.rs
@@ -3,8 +3,11 @@ use core::mem::ManuallyDrop;
 use core::ops::Deref;
 
 use crate::{
-    FlexStr, HeapStr, LocalStr, SharedStr, StorageType, PTR_SIZED_PAD, STRING_SIZED_INLINE,
+    FlexStr, HeapStr, LocalStr, StorageType, PTR_SIZED_PAD, STRING_SIZED_INLINE,
 };
+
+#[cfg(target_has_atomic = "ptr")]
+use crate::SharedStr;
 
 // *** Repeat custom trait ***
 
@@ -560,11 +563,13 @@ impl_float_local_str!(f32, f64);
 /// let a = "This is a heap allocated string!!!!!".to_shared_str();
 /// assert!(a.is_heap());
 /// ```
+#[cfg(target_has_atomic = "ptr")]
 pub trait ToSharedStr {
     /// Converts the source to a [SharedStr] without consuming it
     fn to_shared_str(&self) -> SharedStr;
 }
 
+#[cfg(target_has_atomic = "ptr")]
 impl<HEAP> ToSharedStr for FlexStr<STRING_SIZED_INLINE, PTR_SIZED_PAD, PTR_SIZED_PAD, HEAP>
 where
     HEAP: Clone + Deref<Target = str>,
@@ -582,6 +587,7 @@ where
     }
 }
 
+#[cfg(target_has_atomic = "ptr")]
 impl ToSharedStr for str {
     /// ```
     /// use flexstr::ToSharedStr;
@@ -596,6 +602,7 @@ impl ToSharedStr for str {
     }
 }
 
+#[cfg(target_has_atomic = "ptr")]
 impl ToSharedStr for bool {
     /// ```
     /// use flexstr::ToSharedStr;
@@ -610,6 +617,7 @@ impl ToSharedStr for bool {
     }
 }
 
+#[cfg(target_has_atomic = "ptr")]
 impl ToSharedStr for char {
     /// ```
     /// use flexstr::ToSharedStr;
@@ -725,11 +733,13 @@ impl IntoLocalStr for String {
 /// let a = shared_str!("This is a wrapped static string literal no matter how long it is!!!!!");
 /// assert!(a.is_static());
 /// ```
+#[cfg(target_has_atomic = "ptr")]
 pub trait IntoSharedStr {
     /// Converts the source to an [SharedStr] while consuming the original
     fn into_shared_str(self) -> SharedStr;
 }
 
+#[cfg(target_has_atomic = "ptr")]
 impl<HEAP> IntoSharedStr for FlexStr<STRING_SIZED_INLINE, PTR_SIZED_PAD, PTR_SIZED_PAD, HEAP>
 where
     HEAP: Deref<Target = str>,
@@ -749,6 +759,7 @@ where
     }
 }
 
+#[cfg(target_has_atomic = "ptr")]
 impl IntoSharedStr for String {
     /// ```
     /// use flexstr::IntoSharedStr;


### PR DESCRIPTION
`alloc::sync::Arc` is only available on platforms that support atomic loads and stores of pointers. Some targets don't have this (e.g. thumbv6, RP2040) and flexstr fails to compile.

This PR gates `SharedStr` behind `#[cfg(target_has_atomic = "ptr")]` as recommended by the [documentation](https://doc.rust-lang.org/stable/alloc/sync/struct.Arc.html) for `Arc`. 