### PR TITLE
Dereference before calling `partial_cmp`

### DIFF
--- a/flexstr/src/impls.rs
+++ b/flexstr/src/impls.rs
@@ -198,7 +198,7 @@ where
 {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        str::partial_cmp(self, other)
+        str::partial_cmp(self, &**other)
     }
 }
 


### PR DESCRIPTION
This avoids relying on automatic dereference in the compiler, which can
fail if any other trait impls are available.
